### PR TITLE
Support for more OSC settings to work on multi ps systems.

### DIFF
--- a/modules/Tracker/src/com/pulsefield/tracker/Particle.java
+++ b/modules/Tracker/src/com/pulsefield/tracker/Particle.java
@@ -40,18 +40,18 @@ class Particle {
 		this.location = location.copy();
 	}
 
-	Particle(PVector location, ParticleSystem ps) {
+	Particle(PVector location, ParticleSystemSettings pss) {
 		this(location);
-		adoptSettingsFromParticleSystem(ps);
+		loadParticleSystemSettings(pss);
 	}
 
-	void adoptSettingsFromParticleSystem(ParticleSystem ps) {
-		PVector acceleration = Particle.genRandomVector(ps.particleRandomDriftAccel, ps.tiltx, ps.tilty);
+	void loadParticleSystemSettings(ParticleSystemSettings pss) {
+		PVector acceleration = Particle.genRandomVector(pss.particleRandomDriftAccel, pss.tiltx, pss.tilty);
 		this.acceleration = acceleration;
-		this.fadeDeath = ps.fadeDeath;
-		this.rotationRate = ps.particleRotation;
-		this.setLifespan(ps.particleMaxLife);
-		this.opacity = ps.startOpacity;
+		this.fadeDeath = pss.fadeDeath;
+		this.rotationRate = pss.particleRotation;
+		this.setLifespan(pss.particleMaxLife);
+		this.opacity = pss.startOpacity;
 	}
 
 	void setLifespan(int lifespan) {
@@ -173,8 +173,8 @@ class TextParticle extends Particle {
 		this.text = text;
 	}	
 	
-	TextParticle(PVector location, ParticleSystem ps, String text) {
-		super(location, ps);
+	TextParticle(PVector location, ParticleSystemSettings pss, String text) {
+		super(location, pss);
 		this.text = text;
 	}
 
@@ -193,8 +193,8 @@ class TriangleParticle extends Particle {
 		super(location);
 	}
 	
-	TriangleParticle(PVector location, ParticleSystem ps) {
-		super(location, ps);
+	TriangleParticle(PVector location, ParticleSystemSettings pss) {
+		super(location, pss);
 	}
 
 	@Override
@@ -216,8 +216,8 @@ class ImageParticle extends Particle {
 		super(location);
 	}
 	
-	ImageParticle(PVector location, ParticleSystem ps, PImage image) {
-		super(location, ps);
+	ImageParticle(PVector location, ParticleSystemSettings pss, PImage image) {
+		super(location, pss);
 		this.image = image;
 	}
 

--- a/modules/Tracker/src/com/pulsefield/tracker/VisualizerGravity.java
+++ b/modules/Tracker/src/com/pulsefield/tracker/VisualizerGravity.java
@@ -98,12 +98,16 @@ public class VisualizerGravity extends VisualizerParticleSystem {
 
 	
 	void setUniverseDefaults() {
-		universe.maxParticles = 20000;
-		universe.particleRandomDriftAccel = 0.000008f;
-		universe.particleMaxLife = 500;
-		universe.forceRotation = 340.0f;
-		universe.particleScale = 0.5f;
-		universe.personForce = 0.001f;
+		ParticleSystemSettings pss = new ParticleSystemSettings();
+		
+		pss.maxParticles = 20000;
+		pss.particleRandomDriftAccel = 0.000008f;
+		pss.particleMaxLife = 500;
+		pss.forceRotation = 340.0f;
+		pss.particleScale = 0.5f;
+		pss.personForce = 0.001f;
+		
+		universe.settings = pss;
 	}
 
 	@Override
@@ -144,12 +148,12 @@ public class VisualizerGravity extends VisualizerParticleSystem {
 					PVector corner2Velocity = Tracker.getFloorCenter().sub(Tracker.normalizedToFloor(corner2))
 							.normalize().div(30).rotate(-0.5f);
 
-					Particle particle1 = new ImageParticle(corner1, universe, textures.get("circle.png"));
+					Particle particle1 = new ImageParticle(corner1, universe.settings, textures.get("circle.png"));
 					particle1.velocity = corner1Velocity;
 					particle1.color = goal1.color;
 					particle1.rotationRadians = 0.0f;
 
-					Particle particle2 = new ImageParticle(corner2, universe, textures.get("circle.png"));
+					Particle particle2 = new ImageParticle(corner2, universe.settings, textures.get("circle.png"));
 					particle2.velocity = corner2Velocity;
 					particle2.color = goal2.color;
 					particle2.rotationRadians = 0.0f;
@@ -160,7 +164,7 @@ public class VisualizerGravity extends VisualizerParticleSystem {
 
 				// Just some fluff particles for more visual interest.
 				Particle particleFluff = new ImageParticle(
-						Particle.genRandomVector(Tracker.getFloorDimensionMax() / 2, 0f, 0f), universe,
+						Particle.genRandomVector(Tracker.getFloorDimensionMax() / 2, 0f, 0f), universe.settings,
 						textures.get("blur.png"));
 				particleFluff.velocity = Particle.genRandomVector(0.005f / 300, 0.0f, 0.0f);
 				particleFluff.color = 0x99FFFFFF;
@@ -199,7 +203,7 @@ public class VisualizerGravity extends VisualizerParticleSystem {
 
 			// Increase gravity if a person is moving making dynamic
 			// solutions to the game interesting.
-			universe.attractor(pos.getOriginInMeters(), sign * universe.personForce
+			universe.attractor(pos.getOriginInMeters(), sign * universe.settings.personForce
 					* (float) Math.min(Math.max(pos.getVelocityInMeters().mag() * 3.0f, 1.0), 2.0));
 		}
 

--- a/modules/Tracker/src/com/pulsefield/tracker/VisualizerPS.java
+++ b/modules/Tracker/src/com/pulsefield/tracker/VisualizerPS.java
@@ -28,19 +28,23 @@ public class VisualizerPS extends VisualizerParticleSystem {
 	
 	@Override
 	void setUniverseDefaults() {
-		universe.tilty = -0.03f / 300;
-		universe.particleMaxLife = 500;
-		universe.startOpacity = 0.05f;
-		universe.forceRotation = 90;
-		universe.particleRandomDriftAccel = 0.0f;
-		universe.blendMode = -1; // Use custom blend.
-		universe.personForce = 0f;
+		ParticleSystemSettings pss = new ParticleSystemSettings();
+		
+		pss.tilty = -0.03f / 300;
+		pss.particleMaxLife = 500;
+		pss.startOpacity = 0.05f;
+		pss.forceRotation = 90;
+		pss.particleRandomDriftAccel = 0.0f;
+		pss.blendMode = -1; // Use custom blend.
+		pss.personForce = 0f;
+		
+		universe.settings = pss;
 	}
 
 	public void update(PApplet parent, People p) {
 		for (int id: p.pmap.keySet()) {
 			Person pos=p.pmap.get(id);
-			ParticleSystem ps=systems.get(id);			
+			ParticleSystem ps=systems.get(id);
 			if (ps==null) {
 				logger.fine("Added new particle system for ID "+id);
 				ps=new ParticleSystem();
@@ -58,11 +62,11 @@ public class VisualizerPS extends VisualizerParticleSystem {
 				}
 
 			for (int k=0;k<birthrate;k++) {
-				Particle particle = new ImageParticle(pos.getOriginInMeters(), ps, img);
+				Particle particle = new ImageParticle(pos.getOriginInMeters(), ps.settings, img);
 				
 				particle.color = pos.getcolor();
 				particle.velocity = Particle.fuzzVector(new PVector(0f,0f), 0.3f/300, 0.3f/300);
-				particle.adoptSettingsFromParticleSystem(universe);
+				particle.loadParticleSystemSettings(universe.settings);
 				
 				ps.addParticle(particle);
 			}
@@ -71,10 +75,13 @@ public class VisualizerPS extends VisualizerParticleSystem {
 
 		for (Map.Entry<Integer,ParticleSystem> me: systems.entrySet()) {
 			ParticleSystem ps=me.getValue();
+			
+			// Use universe as the template for all the particle systems.
+			ps.settings = universe.settings;
 			ps.update();
 			
-			if (universe.personForce != 0f) {
-				applyPeopleGravity(ps, p, universe.personForce);
+			if (universe.settings.personForce != 0f) {
+				ps.applyPeopleGravity(p);
 			}
 
 			int id = me.getKey();

--- a/modules/Tracker/src/com/pulsefield/tracker/VisualizerParticleSystem.java
+++ b/modules/Tracker/src/com/pulsefield/tracker/VisualizerParticleSystem.java
@@ -69,24 +69,13 @@ class VisualizerParticleSystem extends Visualizer {
 		}
 	}
 
-	static void applyPeopleGravity(ParticleSystem ps, People p, float force) {
-		for (int id : p.pmap.keySet()) {
-			Person pos = p.pmap.get(id);
-			ps.attractor(pos.getOriginInMeters(), force);
-		}
-	}
-	
-	void applyPeopleGravity(People p) {
-		applyPeopleGravity(universe, p, universe.personForce);
-	}
-
 	// Apply gravity for persons scaling the effect based on their leg
 	// separation.
 	void applyPeopleGravityLegScaled(People p) {
 		for (int id : p.pmap.keySet()) {
 			Person pos = p.pmap.get(id);
 			universe.attractor(pos.getOriginInMeters(),
-					(float) (universe.personForce * (1.2 - pos.getLegSeparationInMeters())));
+					(float) (universe.settings.personForce * (1.2 - pos.getLegSeparationInMeters())));
 		}
 	}
 
@@ -116,21 +105,21 @@ class VisualizerParticleSystem extends Visualizer {
 		if (components.length < 3 || !components[2].equals(oscName))
 			logger.warning("VisualizerParticleSystem: Expected /video/" + oscName + " messages, got " + msg.toString());
 		else if (components.length == 4 && components[3].equals("maxparticles")) {
-			universe.maxParticles = (long) Math.pow(2, msg.get(0).floatValue());
+			universe.settings.maxParticles = (long) Math.pow(2, msg.get(0).floatValue());
 		} else if (components.length == 4 && components[3].equals("particledispersion")) {
-			universe.particleRandomDriftAccel = msg.get(0).floatValue();
+			universe.settings.particleRandomDriftAccel = msg.get(0).floatValue();
 		} else if (components.length == 4 && components[3].equals("forcerotation")) {
-			universe.forceRotation = msg.get(0).floatValue();
+			universe.settings.forceRotation = msg.get(0).floatValue();
 		} else if (components.length == 4 && components[3].equals("particlerotation")) {
-			universe.particleRotation = msg.get(0).floatValue();
+			universe.settings.particleRotation = msg.get(0).floatValue();
 		} else if (components.length == 4 && components[3].equals("particlemaxlife")) {
-			universe.particleMaxLife = (int) msg.get(0).floatValue();
+			universe.settings.particleMaxLife = (int) msg.get(0).floatValue();
 		} else if (components.length == 4 && components[3].equals("particleopacity")) {
-			universe.startOpacity = msg.get(0).floatValue();
+			universe.settings.startOpacity = msg.get(0).floatValue();
 		} else if (components.length == 4 && components[3].equals("persongravity")) {
-			universe.personForce = msg.get(0).floatValue();
+			universe.settings.personForce = msg.get(0).floatValue();
 		} else if (components.length == 4 && components[3].equals("particlescale")) {
-			universe.particleScale = msg.get(0).floatValue();
+			universe.settings.particleScale = msg.get(0).floatValue();
 		} else if (components.length == 6 && components[3].equals("blendmode")) {
 			handleBlendSettingMessage(msg);
 		} else if (components.length == 4 && components[3].equals("tilt")) {
@@ -144,8 +133,8 @@ class VisualizerParticleSystem extends Visualizer {
 	private void handleTilt(OscMessage msg) {
 		msg.addrPattern().split("/");
 
-		universe.tiltx = msg.get(0).floatValue() * 0.0001f;
-		universe.tilty = msg.get(1).floatValue() * 0.0001f;
+		universe.settings.tiltx = msg.get(0).floatValue() * 0.0001f;
+		universe.settings.tilty = msg.get(1).floatValue() * 0.0001f;
 	}
 
 	private void handleBlendSettingMessage(OscMessage msg) {
@@ -162,28 +151,28 @@ class VisualizerParticleSystem extends Visualizer {
 
 			switch (clicked) {
 			case "2/1":
-				universe.blendMode = -1; // Custom.
+				universe.settings.blendMode = -1; // Custom.
 				break;
 			case "2/2":
-				universe.blendMode = PConstants.ADD;
+				universe.settings.blendMode = PConstants.ADD;
 				break;
 			case "2/3":
-				universe.blendMode = PConstants.SUBTRACT;
+				universe.settings.blendMode = PConstants.SUBTRACT;
 				break;
 			case "2/4":
-				universe.blendMode = PConstants.SCREEN;
+				universe.settings.blendMode = PConstants.SCREEN;
 				break;
 			case "1/1":
-				universe.blendMode = PConstants.LIGHTEST;
+				universe.settings.blendMode = PConstants.LIGHTEST;
 				break;
 			case "1/2":
-				universe.blendMode = PConstants.BLEND;
+				universe.settings.blendMode = PConstants.BLEND;
 				break;
 			case "1/3":
-				universe.blendMode = PConstants.OVERLAY;
+				universe.settings.blendMode = PConstants.OVERLAY;
 				break;
 			case "1/4":
-				universe.blendMode = PConstants.MULTIPLY;
+				universe.settings.blendMode = PConstants.MULTIPLY;
 				break;
 			}
 		}
@@ -200,14 +189,14 @@ class VisualizerParticleSystem extends Visualizer {
 	}
 
 	public void setTO() {
-		setTOValue("maxparticles", Math.log(universe.maxParticles) / Math.log(2), "%.4f");
-		setTOValue("particleaccel", universe.particleRandomDriftAccel, "%.4f");
-		setTOValue("forcerotation", universe.forceRotation, "%.4f");
-		setTOValue("particlerotation", universe.particleRotation, "%.4f");
-		setTOValue("particlemaxlife", universe.particleMaxLife, "%.4f");
-		setTOValue("particleopacity", universe.startOpacity, "%.4f");
-		setTOValue("persongravity", universe.personForce, "%.4f");
-		setTOValue("particlescale", universe.particleScale, "%.4f");
+		setTOValue("maxparticles", Math.log(universe.settings.maxParticles) / Math.log(2), "%.4f");
+		setTOValue("particleaccel", universe.settings.particleRandomDriftAccel, "%.4f");
+		setTOValue("forcerotation", universe.settings.forceRotation, "%.4f");
+		setTOValue("particlerotation", universe.settings.particleRotation, "%.4f");
+		setTOValue("particlemaxlife", universe.settings.particleMaxLife, "%.4f");
+		setTOValue("particleopacity", universe.settings.startOpacity, "%.4f");
+		setTOValue("persongravity", universe.settings.personForce, "%.4f");
+		setTOValue("particlescale", universe.settings.particleScale, "%.4f");
 
 		setTiltTO();
 	}
@@ -216,17 +205,8 @@ class VisualizerParticleSystem extends Visualizer {
 		TouchOSC to = TouchOSC.getInstance();
 		OscMessage set = new OscMessage("/video/" + oscName + "/tilt");
 		set.add("set");
-		set.add(universe.tiltx);
-		set.add(universe.tilty);
+		set.add(universe.settings.tiltx);
+		set.add(universe.settings.tilty);
 		to.sendMessage(set);
-		
-		/* 
-		set = new OscMessage("/video/" + oscName + "/tilt"  + "/value");
-		set.
-		set.add(String.format("%.4f", universe.tiltx));
-		set.add(String.format("%.4f", universe.tilty));
-		
-		PApplet.println(" sending message : " + set);
-		to.sendMessage(set); */
 	}
 }

--- a/modules/Tracker/src/com/pulsefield/tracker/VisualizerRainbow.java
+++ b/modules/Tracker/src/com/pulsefield/tracker/VisualizerRainbow.java
@@ -18,12 +18,16 @@ public class VisualizerRainbow extends VisualizerParticleSystem {
 
 	@Override
 	void setUniverseDefaults() {
-		universe.maxParticles = 20000;
-		universe.particleScale = 0.15f;
-		universe.personForce = 0.005f;
-		universe.particleRotation = 0.25f;
-		universe.forceRotation = 3.0f;
-		universe.particleMaxLife = 175;
+		ParticleSystemSettings pss = new ParticleSystemSettings();
+		
+		pss.maxParticles = 20000;
+		pss.particleScale = 0.15f;
+		pss.personForce = 0.005f;
+		pss.particleRotation = 0.25f;
+		pss.forceRotation = 3.0f;
+		pss.particleMaxLife = 175;
+		
+		universe.settings = pss;
 	}
 	
 	@Override
@@ -40,7 +44,7 @@ public class VisualizerRainbow extends VisualizerParticleSystem {
 			float distanceFromCenter, PVector center) {
 
 		PVector origin = center.copy().add(new PVector(0, distanceFromCenter).rotate(rotation));
-		Particle p = new ImageParticle(origin, universe, textures.get("oval.png"));
+		Particle p = new ImageParticle(origin, universe.settings, textures.get("oval.png"));
 		p.color = color;
 
 		PVector velocityV = center.copy().sub(origin).normalize().setMag(velocity).rotate(angle);
@@ -53,7 +57,7 @@ public class VisualizerRainbow extends VisualizerParticleSystem {
 	public void update(PApplet parent, People p) {
 		int particlesPerUpdate = 360;
 		rainbowAdvance = (rainbowAdvance + rainbowAdvanceIncrement) % 360;
-
+		
 		// Create some particles unless there are too many already.
 		if (universe.particlesRemaining() >= 360) {
 			for (int i = 0; i < particlesPerUpdate; i++) {


### PR DESCRIPTION
I re-arranged the particle settings data to make it better support multiple-particle-system visualization controls.  With this, TouchOSC can control more aspects of particles (scale, opacity, blending modes, etc) in e.g. Grid, etc.